### PR TITLE
Update buildapp.yml dependences 

### DIFF
--- a/.github/workflows/buildapp.yml
+++ b/.github/workflows/buildapp.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       cercube_version:
         description: "The version of Cercube"
-        default: "5.3.11"
+        default: "5.3.12"
         required: true
         type: string
       decrypted_youtube_url:
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   build:
     name: Build CercubePlus
-    runs-on: macos-latest
+    runs-on: macos-11
     permissions:
       contents: write
 
@@ -131,7 +131,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.15
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CERCUBE_VERSION: ${{ inputs.CERCUBE_VERSION }}


### PR DESCRIPTION
updated default Cercube Version
updated Softprops Dependences to 0.1.15
CercubePlus uses MacOS-11 to build ipa (from uYouPlus)
this should hopefully make CercubePlus’s buildapp file last longer in the future like uYouPlus.